### PR TITLE
Removed memory-leak eating all the memory at least on linux mint 

### DIFF
--- a/src/listener.cc
+++ b/src/listener.cc
@@ -789,9 +789,8 @@ void AuditListener::exec()
             default:
                 break;
         }
-        auparse_reset(au);
+        auparse_destroy(au);
     }
-    auparse_destroy(au);
 }
 
 


### PR DESCRIPTION
This situtation happens when another audit client is present during (late) startup. In this case, many audit events occur. The problem is, that a data structure allocated by auparse_init() seems to need a corresponding call of auparse_destroy() to cleanup all its memory. Currently, only auparse_reset() is used. Due to unclear documentation of these auparse function, the original author made this mistake.

The memory leak was found with valgrind. The fix is trivial.

Valgrind found some other minor memory leaks during parsing of config file. I did not fix them, because the eaten memory of these leaks does of course not steadily increase during runtime.  